### PR TITLE
Toggle Wireframe Mode(Updated)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -347,8 +347,23 @@ void processInput(GLFWwindow* window)
         camera.Reset();
         std::cout << "Camera reset!\n";
     }
-}
+    //Toggle wireframe mode
+    static bool wireframe = false;
+    static bool keyPressed = false;
 
+    if (glfwGetKey(window, GLFW_KEY_F) == GLFW_PRESS && !keyPressed)
+    {
+        wireframe = !wireframe;
+        glPolygonMode(GL_FRONT_AND_BACK, wireframe ? GL_LINE : GL_FILL);
+        keyPressed = true;
+        std::cout << "Wireframe mode: " << (wireframe ? "ON" : "OFF") << std::endl;
+    }
+
+    if (glfwGetKey(window, GLFW_KEY_F) == GLFW_RELEASE)
+    {
+        keyPressed = false;
+    }
+}
 // glfw: whenever the window size changed (by OS or user resize) this callback function executes
 // ---------------------------------------------------------------------------------------------
 void framebuffer_size_callback(GLFWwindow* window, int width, int height)


### PR DESCRIPTION
## Solves Issue #2 
## Summary Of Features
1. Wireframe toggle key: Press F to switch between solid and wireframe rendering.
2. Dual rendering modes: Allows users to view the cube as a filled 3D object or a wireframe outline.
3. Instant visual feedback: Changes the polygon rendering mode immediately upon key press.
4. Debounced input: Ensures the toggle occurs only once per key press, preventing rapid switching.
5. Debugging aid: Helps visualize the underlying geometry and vertex connections of the cube.
6. Minimal performance impact: Simple OpenGL mode switch—no heavy processing or re-rendering needed.

If you still find any errors or issues please comment. Thank you.