### PR TITLE
Restore camera reset key binding

### DIFF
--- a/includes/core/Constants.h
+++ b/includes/core/Constants.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <thirdparty/glm/glm.hpp>
+
 namespace Bindings 
 {
     // Uniform Buffer Binding Points
@@ -15,4 +17,21 @@ namespace Bindings
     constexpr int TEX_SLOT_CSM_SHADOW   = 10;
     constexpr int TEX_SLOT_POINT_SHADOW = 11;
     constexpr int TEX_SLOT_SKYBOX       = 15;
+}
+
+//Camera Defaults
+namespace CameraDefaults
+{
+    inline constexpr float YAW   = -90.0f;
+    inline constexpr float PITCH = 0.0f;
+    inline constexpr float SPEED = 10.0f;
+    inline constexpr float SENSITIVITY = 0.1f;
+    inline constexpr float ZOOM  = 45.0f;
+
+    inline constexpr float NEAR_PLANE = 0.1f;
+    inline constexpr float FAR_PLANE  = 100.0f;
+
+    inline constexpr glm::vec3 POSITION = glm::vec3(0.0f, 0.0f, 3.0f);
+    inline constexpr glm::vec3 UP       = glm::vec3(0.0f, 1.0f, 0.0f);
+    inline constexpr glm::vec3 FRONT    = glm::vec3(0.0f, 0.0f, -1.0f);
 }

--- a/includes/helpers/camera.h
+++ b/includes/helpers/camera.h
@@ -4,7 +4,9 @@
 #include <thirdparty/glm/glm.hpp>
 #include <thirdparty/glm/gtc/matrix_transform.hpp>
 
-// Defines several possible options for camera movement. Used as abstraction to stay away from window-system specific input methods
+#include "../core/Constants.h"
+
+// Defines several possible options for camera movement
 enum Camera_Movement {
     FORWARD,
     BACKWARD,
@@ -12,14 +14,7 @@ enum Camera_Movement {
     RIGHT
 };
 
-// Default camera values
-const float YAW = -90.0f;
-const float PITCH = 0.0f;
-const float SPEED = 10.0f;
-const float SENSITIVITY = 0.1f;
-const float ZOOM = 45.0f;
-
-// An abstract camera class that processes input and calculates the corresponding Euler Angles, Vectors and Matrices for use in OpenGL
+// An abstract camera class
 class Camera
 {
 public:
@@ -29,122 +24,127 @@ public:
     glm::vec3 Up;
     glm::vec3 Right;
     glm::vec3 WorldUp;
+
     // euler Angles
     float Yaw;
     float Pitch;
+
     // camera options
     float MovementSpeed;
     float MouseSensitivity;
     float Zoom;
-    float Near = 0.1f;
-    float Far = 500.0f;
+    float Near;
+    float Far;
 
     // constructor with vectors
-    Camera(glm::vec3 position = glm::vec3(0.0f, 0.0f, 3.0f), 
-            glm::vec3 up = glm::vec3(0.0f, 1.0f, 0.0f), 
-            float yaw = YAW, 
-            float pitch = PITCH) : 
-            Front(glm::vec3(0.0f, 0.0f, -1.0f)), 
-            MovementSpeed(SPEED), MouseSensitivity(SENSITIVITY), Zoom(ZOOM)
+    Camera(
+        glm::vec3 position = CameraDefaults::POSITION,
+        glm::vec3 up       = CameraDefaults::UP,
+        float yaw          = CameraDefaults::YAW,
+        float pitch        = CameraDefaults::PITCH
+    )
+        : Front(CameraDefaults::FRONT),
+          MovementSpeed(CameraDefaults::SPEED),
+          MouseSensitivity(CameraDefaults::SENSITIVITY),
+          Zoom(CameraDefaults::ZOOM),
+          Near(CameraDefaults::NEAR_PLANE),
+          Far(CameraDefaults::FAR_PLANE)
     {
         Position = position;
-        WorldUp = up;
-        Yaw = yaw;
-        Pitch = pitch;
+        WorldUp  = up;
+        Yaw      = yaw;
+        Pitch    = pitch;
         updateCameraVectors();
     }
 
     // constructor with scalar values
-    Camera(float posX, float posY, float posZ,
-        float upX, float upY, float upZ,
-        float yaw, float pitch)
-        : Front(glm::vec3(0.0f, 0.0f, -1.0f)),
-        MovementSpeed(SPEED),
-        MouseSensitivity(SENSITIVITY),
-        Zoom(ZOOM)
+    Camera(
+        float posX, float posY, float posZ,
+        float upX,  float upY,  float upZ,
+        float yaw,  float pitch
+    )
+        : Front(CameraDefaults::FRONT),
+          MovementSpeed(CameraDefaults::SPEED),
+          MouseSensitivity(CameraDefaults::SENSITIVITY),
+          Zoom(CameraDefaults::ZOOM),
+          Near(CameraDefaults::NEAR_PLANE),
+          Far(CameraDefaults::FAR_PLANE)
     {
         Position = glm::vec3(posX, posY, posZ);
-        WorldUp = glm::vec3(upX, upY, upZ);
-        Yaw = yaw;
-        Pitch = pitch;
+        WorldUp  = glm::vec3(upX, upY, upZ);
+        Yaw      = yaw;
+        Pitch    = pitch;
         updateCameraVectors();
     }
 
     void ResetProjection()
     {
-        Zoom = ZOOM; 
-        Near = 0.1f;
-        Far = 100.0f;
+        Zoom = CameraDefaults::ZOOM;
+        Near = CameraDefaults::NEAR_PLANE;
+        Far  = CameraDefaults::FAR_PLANE;
     }
 
     void Reset()
     {
-        Position = glm::vec3(0.0f, 0.0f, 3.0f);
-        Front = glm::vec3(0.0f, 0.0f, -1.0f);
-        Up = glm::vec3(0.0f, 1.0f, 0.0f);
-        Yaw = YAW;
-        Pitch = PITCH;
-        Zoom = ZOOM;
+        Position = CameraDefaults::POSITION;
+        Front    = CameraDefaults::FRONT;
+        Up       = CameraDefaults::UP;
+        Yaw      = CameraDefaults::YAW;
+        Pitch    = CameraDefaults::PITCH;
+        Zoom     = CameraDefaults::ZOOM;
+
         updateCameraVectors();
         ResetProjection();
     }
 
-    // returns the view matrix calculated using Euler Angles and the LookAt Matrix
     glm::mat4 GetViewMatrix() const
     {
         return glm::lookAt(Position, Position + Front, Up);
     }
 
-    // processes input received from any keyboard-like input system
     void ProcessKeyboard(Camera_Movement direction, float deltaTime)
     {
         float velocity = MovementSpeed * deltaTime;
-        if (direction == FORWARD)
-            Position += Front * velocity;
-        if (direction == BACKWARD)
-            Position -= Front * velocity;
-        if (direction == LEFT)
-            Position -= Right * velocity;
-        if (direction == RIGHT)
-            Position += Right * velocity;
+        if (direction == FORWARD)  Position += Front * velocity;
+        if (direction == BACKWARD) Position -= Front * velocity;
+        if (direction == LEFT)     Position -= Right * velocity;
+        if (direction == RIGHT)    Position += Right * velocity;
     }
 
-    // processes input received from a mouse input system
     void ProcessMouseMovement(float xoffset, float yoffset, GLboolean constrainPitch = true)
     {
         xoffset *= MouseSensitivity;
         yoffset *= MouseSensitivity;
 
-        Yaw += xoffset;
+        Yaw   += xoffset;
         Pitch += yoffset;
 
         if (constrainPitch)
         {
-            if (Pitch > 89.0f) Pitch = 89.0f;
+            if (Pitch > 89.0f)  Pitch = 89.0f;
             if (Pitch < -89.0f) Pitch = -89.0f;
         }
 
         updateCameraVectors();
     }
 
-    // processes input received from a mouse scroll-wheel event
     void ProcessMouseScroll(float yoffset)
     {
         Zoom -= (float)yoffset;
-        if (Zoom < 1.0f) Zoom = 1.0f;
+        if (Zoom < 1.0f)  Zoom = 1.0f;
         if (Zoom > 45.0f) Zoom = 45.0f;
     }
 
 private:
-    // calculates the front vector from the Camera's (updated) Euler Angles
     void updateCameraVectors()
     {
         glm::vec3 front;
         front.x = cos(glm::radians(Yaw)) * cos(glm::radians(Pitch));
         front.y = sin(glm::radians(Pitch));
         front.z = sin(glm::radians(Yaw)) * cos(glm::radians(Pitch));
+
         Front = glm::normalize(front);
         Right = glm::normalize(glm::cross(Front, WorldUp));
-        Up = glm::normalize(glm::cross(Right, Front));
+        Up    = glm::normalize(glm::cross(Right, Front));
     }
 };

--- a/src/application/Application.cpp
+++ b/src/application/Application.cpp
@@ -63,6 +63,11 @@ void Application::ConfigureInput()
         app->camera.ProcessKeyboard(RIGHT, dt); 
     });
 
+      // camera reset
+    input->BindKeyEvent(GLFW_KEY_R, GLFW_PRESS, [app]() {
+        app->camera.Reset();
+    });
+
     // mouse
     input->BindMouseMove([app](double x, double y) {
         app->camera.ProcessMouseMovement((float)x, (float)y);


### PR DESCRIPTION
### Summary
This PR restores the camera reset functionality 

### What is Changed:
Pressing `R` now:
Resets the camera to its default position and resets the orientation to face the scene center.
The fix is implemented using the existing input binding system and the camera’s public reset API, keeping the change minimal and isolated.

