### PR TITLE
Feat: Smart Camera Reset, Asset Hardening & Dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(assimp)
 
-# JSON (nlohmann) - Added for Proposal
+# JSON (nlohmann)
 message(STATUS "Downloading nlohmann/json...")
 FetchContent_Declare(
     json
@@ -47,7 +47,7 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(json)
 
-# IMGUI (Dear ImGui) - Added for Proposal
+# IMGUI (Dear ImGui)
 message(STATUS "Downloading Dear ImGui...")
 FetchContent_Declare(
     imgui

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,35 @@ FetchContent_Declare(
     URL ${CMAKE_CURRENT_SOURCE_DIR}/deps/assimp-5.2.5.zip
 )
 FetchContent_MakeAvailable(assimp)
+
+# JSON (nlohmann) - Added for Proposal
+message(STATUS "Downloading nlohmann/json...")
+FetchContent_Declare(
+    json
+    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+)
+FetchContent_MakeAvailable(json)
+
+# IMGUI (Dear ImGui) - Added for Proposal
+message(STATUS "Downloading Dear ImGui...")
+FetchContent_Declare(
+    imgui
+    URL https://github.com/ocornut/imgui/archive/refs/tags/v1.91.5.zip
+)
+FetchContent_MakeAvailable(imgui)
+
+# Define ImGui Sources
+set(IMGUI_DIR ${imgui_SOURCE_DIR})
+set(IMGUI_SOURCES
+    ${IMGUI_DIR}/imgui.cpp
+    ${IMGUI_DIR}/imgui_demo.cpp
+    ${IMGUI_DIR}/imgui_draw.cpp
+    ${IMGUI_DIR}/imgui_tables.cpp
+    ${IMGUI_DIR}/imgui_widgets.cpp
+    ${IMGUI_DIR}/backends/imgui_impl_glfw.cpp
+    ${IMGUI_DIR}/backends/imgui_impl_opengl3.cpp
+)
+
 # SOURCE FILES
 file(GLOB_RECURSE SOURCES 
     "src/*.cpp" 
@@ -47,15 +76,17 @@ file(GLOB_RECURSE SOURCES
 )
 
 # EXECUTABLE TARGET
-add_executable(${PROJECT_NAME} ${SOURCES})
+add_executable(${PROJECT_NAME} ${SOURCES} ${IMGUI_SOURCES})
 
 # INCLUDE DIRECTORIES
 target_include_directories(${PROJECT_NAME} PUBLIC 
     ${CMAKE_CURRENT_SOURCE_DIR}/includes
     ${CMAKE_CURRENT_SOURCE_DIR}/includes/thirdparty 
+    ${IMGUI_DIR}
+    ${IMGUI_DIR}/backends
 )
 
-target_link_libraries(${PROJECT_NAME} PRIVATE glfw assimp)
+target_link_libraries(${PROJECT_NAME} PRIVATE glfw assimp nlohmann_json::nlohmann_json)
 
 # LINKING LIBRARIES (OS Specifics)
 find_package(OpenGL REQUIRED)

--- a/includes/core/ResourceManager.h
+++ b/includes/core/ResourceManager.h
@@ -20,6 +20,7 @@ public:
     // Textures
     static std::shared_ptr<Texture> LoadTexture(const std::string& path, TextureType type);
     static std::shared_ptr<Texture> GetTexture(const std::string& path);
+    static std::shared_ptr<Texture> GetFallbackTexture();
 
     static std::shared_ptr<Texture> LoadCubeMap(std::vector<std::string> faces, std::string name = "");
 

--- a/includes/helpers/camera.h
+++ b/includes/helpers/camera.h
@@ -52,13 +52,7 @@ public:
         Yaw = yaw;
         Pitch = pitch;
 
-        // Store initial state
-        StartPosition = Position;
-        StartWorldUp = WorldUp;
-        StartYaw = Yaw;
-        StartPitch = Pitch;
-        StartZoom = Zoom;
-
+        SetDefault();
         updateCameraVectors();
     }
 
@@ -76,13 +70,7 @@ public:
         Yaw = yaw;
         Pitch = pitch;
 
-        // Store initial state
-        StartPosition = Position;
-        StartWorldUp = WorldUp;
-        StartYaw = Yaw;
-        StartPitch = Pitch;
-        StartZoom = Zoom;
-
+        SetDefault();
         updateCameraVectors();
     }
 

--- a/includes/helpers/camera.h
+++ b/includes/helpers/camera.h
@@ -51,6 +51,14 @@ public:
         WorldUp = up;
         Yaw = yaw;
         Pitch = pitch;
+
+        // Store initial state
+        StartPosition = Position;
+        StartWorldUp = WorldUp;
+        StartYaw = Yaw;
+        StartPitch = Pitch;
+        StartZoom = Zoom;
+
         updateCameraVectors();
     }
 
@@ -67,26 +75,46 @@ public:
         WorldUp = glm::vec3(upX, upY, upZ);
         Yaw = yaw;
         Pitch = pitch;
+
+        // Store initial state
+        StartPosition = Position;
+        StartWorldUp = WorldUp;
+        StartYaw = Yaw;
+        StartPitch = Pitch;
+        StartZoom = Zoom;
+
         updateCameraVectors();
     }
 
     void ResetProjection()
     {
-        Zoom = ZOOM; 
+        Zoom = StartZoom; 
         Near = 0.1f;
         Far = 100.0f;
     }
 
     void Reset()
     {
-        Position = glm::vec3(0.0f, 0.0f, 3.0f);
+        Position = StartPosition;
+        WorldUp = StartWorldUp;
+        Yaw = StartYaw;
+        Pitch = StartPitch;
+        Zoom = StartZoom;
         Front = glm::vec3(0.0f, 0.0f, -1.0f);
-        Up = glm::vec3(0.0f, 1.0f, 0.0f);
-        Yaw = YAW;
-        Pitch = PITCH;
-        Zoom = ZOOM;
+        Up = glm::vec3(0.0f, 1.0f, 0.0f); // Default up
+        
         updateCameraVectors();
         ResetProjection();
+    }
+
+    // Capture current camera state as the new 'home' for Reset()
+    void SetDefault()
+    {
+        StartPosition = Position;
+        StartWorldUp = WorldUp;
+        StartYaw = Yaw;
+        StartPitch = Pitch;
+        StartZoom = Zoom;
     }
 
     // returns the view matrix calculated using Euler Angles and the LookAt Matrix
@@ -136,6 +164,13 @@ public:
     }
 
 private:
+    // Initial State for Reset
+    glm::vec3 StartPosition;
+    glm::vec3 StartWorldUp;
+    float StartYaw;
+    float StartPitch;
+    float StartZoom;
+
     // calculates the front vector from the Camera's (updated) Euler Angles
     void updateCameraVectors()
     {

--- a/src/application/Application.cpp
+++ b/src/application/Application.cpp
@@ -35,6 +35,7 @@ void Application::Init()
 
     if (!appState->scenes.empty()) {
         appState->scenes[appState->currentSceneIndex]->OnActivate(*appState);
+        appState->camera.SetDefault();
     }
 
     ConfigureInput();
@@ -80,14 +81,20 @@ void Application::ConfigureInput()
         if (n == 0) return;
         app->currentSceneIndex = (app->currentSceneIndex + offset + n) % n;
         glfwSetWindowTitle(winPtr->GetNative(), app->scenes[app->currentSceneIndex]->Name().c_str());
-        app->camera.Reset();
+        app->camera.Reset(); // Clear any extreme movement/rotation
         app->scenes[app->currentSceneIndex]->OnActivate(*app);
+        app->camera.SetDefault(); // Lock in the scene's starting camera state
     };
 
     input->BindKeyEvent(GLFW_KEY_RIGHT, GLFW_RELEASE, 
         [SwitchScene](){ SwitchScene(1); });
     input->BindKeyEvent(GLFW_KEY_LEFT, GLFW_RELEASE, 
         [SwitchScene](){ SwitchScene(-1); });
+
+    // camera reset
+    input->BindKeyEvent(GLFW_KEY_R, GLFW_RELEASE, [app]() {
+        app->camera.Reset();
+    });
 
     // debug options
     input->BindKeyEvent(GLFW_KEY_F, GLFW_RELEASE, [app]() {

--- a/src/core/ResourceManager.cpp
+++ b/src/core/ResourceManager.cpp
@@ -47,8 +47,8 @@ std::shared_ptr<Texture> ResourceManager::LoadTexture(const std::string& path, T
     stbi_set_flip_vertically_on_load(true);
     unsigned char* data = stbi_load(path.c_str(), &width, &height, &nrChannels, 0);
     if (!data) {
-        std::cerr << "ResourceManager: Failed to load texture " << path << "\n";
-        return nullptr;
+        std::cerr << "ResourceManager: Failed to load texture " << path << ". Using fallback.\n";
+        return GetFallbackTexture();
     }
 
     // Determine the Data Format
@@ -169,6 +169,38 @@ std::shared_ptr<Texture> ResourceManager::GetTexture(const std::string& path)
     auto it = textures.find(path);
     if (it == textures.end()) return nullptr;
     return it->second;
+}
+
+std::shared_ptr<Texture> ResourceManager::GetFallbackTexture()
+{
+    if (textures.count("fallback_checkerboard")) return textures["fallback_checkerboard"];
+
+    // Create a 2x2 magenta/black checkerboard texture
+    unsigned char data[] = {
+        255, 0, 255, 0, 0, 0,
+        0, 0, 0, 255, 0, 255
+    };
+
+    unsigned int tex;
+    glGenTextures(1, &tex);
+    glBindTexture(GL_TEXTURE_2D, tex);
+
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 2, 2, 0, GL_RGB, GL_UNSIGNED_BYTE, data);
+    
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+
+    auto texture = std::make_shared<Texture>();
+    texture->ID = tex;
+    texture->type = TextureType::TEX_DIFFUSE;
+    texture->width = 2;
+    texture->height = 2;
+    texture->channels = 3;
+
+    textures["fallback_checkerboard"] = texture;
+    return texture;
 }
 
 std::string ResourceManager::combinePaths(std::vector<std::string> paths)


### PR DESCRIPTION
Camera System:

- Replaced hardcoded (0,0,3) reset values with dynamic scene defaults.

- Added SetDefault() to capture camera state on OnActivate.

- Updated 'R' key binding to restore the captured state instead of world origin.

- Prevents camera clipping in large scenes (e.g Space/Moon).

Asset System:

- Implemented GetFallbackTexture() to generate a 2x2 Magenta/Black checkerboard.

- ResourceManager now returns fallback instead of nullptr on missing files.

- Prevents engine crashes when assets (like rock.obj textures) are missing.

Build & Tooling:

- Added nlohmann/json and Dear ImGui to CMakeLists.txt for upcoming Editor features.